### PR TITLE
Add basic Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# petya-drill-bot
+# Petya Drill Bot
+
+This is a simple Telegram bot built with [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot).
+
+## Features
+
+- `/инструкция` &mdash; sends drilling instructions from Petya.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set your bot token in the `TELEGRAM_TOKEN` environment variable.
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,29 @@
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+import os
+
+INSTRUCTION_TEXT = (
+    "Петя говорит:\n"
+    "1. Возьми шуруповёрт.\n"
+    "2. Вруби его на максимум.\n"
+    "3. Шуруп — в дерево.\n"
+    "4. Если сломался — повтори пункт 1."
+)
+
+async def instruction(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(INSTRUCTION_TEXT)
+
+
+def main() -> None:
+    token = os.getenv("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("Please set the TELEGRAM_TOKEN environment variable")
+
+    application = Application.builder().token(token).build()
+    application.add_handler(CommandHandler("инструкция", instruction))
+
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-telegram-bot==20.3
+


### PR DESCRIPTION
## Summary
- implement a simple `python-telegram-bot` bot
- add `/инструкция` command
- document setup and usage
- list dependency

## Testing
- `python3 -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6841a3e2b524832b975df2841432c167